### PR TITLE
Patch initialization for NVCC

### DIFF
--- a/include/spdlog/details/pattern_formatter.h
+++ b/include/spdlog/details/pattern_formatter.h
@@ -624,7 +624,7 @@ class z_formatter final : public flag_formatter
 {
 public:
     explicit z_formatter(padding_info padinfo)
-        : flag_formatter(padinfo){};
+        : flag_formatter(padinfo), last_update_(std::chrono::seconds(0)) {};
 
     const std::chrono::seconds cache_refresh = std::chrono::seconds(5);
 
@@ -662,7 +662,7 @@ public:
     }
 
 private:
-    log_clock::time_point last_update_{std::chrono::seconds(0)};
+    log_clock::time_point last_update_;
 #ifdef _WIN32
     int offset_minutes_{0};
 


### PR DESCRIPTION
It would seem that NVCC 9 has an issue compiling variables that are declared and defined on the same line and where the type is a templated object. This PR moves the definition to get around this issue.